### PR TITLE
Solution to allow xwiimote-mouse in emulators. (tested with retropie).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ Accuracy and latency test: https://www.youtube.com/watch?v=IGNFb0cMnkg
  * https://franklinta.com/2014/09/30/6dof-positional-tracking-with-the-wiimote/
  * http://wiicanetouchgraphic.blogspot.com/2009/03/wii-remote-ir-sensitivity.html
  * http://problemkaputt.de/psx-spx.htm#controllerslightgunsnamcoguncon
+
+## xwiigun-mouse
+UINPUT requires root access in order to function correctly. This causes a problem
+as any applications that wish to use the device are not run as root. Simply running
+xwiigun-mouse with sudo is not enough.
+
+This can be worked around using 2 different methods.
+
+- Method 1 (Temporary):
+
+   Run the following commands to change permissions of uinput:
+   - sudo chmod +0660 /dev/uinput
+   - Run xwiigun-mouse
+
+ - Method 2 (Permanent):
+
+   In order to make the uinput rule permanent we need to tell the uinput module
+   to run at boot and create a rule file to give uinput user permissions.
+   - Navigate to the xwiigun/additional folder
+   - run sudo uinput_fix.sh
+   - sudo reboot
+
+   Note: If this doesnt work, a small change might be required to the uinput_fix.sh
+         file. This is explained within the file itself.
+

--- a/additional/uinput_fix.sh
+++ b/additional/uinput_fix.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#Make sure only root can run the script
+if [ "$(id -u)" != "0" ]; then
+    echo "This script must be run as root"
+    exit 1
+fi
+
+#Make the uinput module load at boot
+echo "uinput" > /etc/modules-load.d/uinput.conf
+
+#Create a rule file that changes the access permissions for uinput.
+#Note: This has only been tested on a retropie setup. If this does
+#      not work for you, try changing GROUP to GROUP="wheel"
+#      and run again.
+echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' > /etc/udev/rules.d/99-wiimote.rules

--- a/mouse.c
+++ b/mouse.c
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
     /* Try to open a uinput device and respond accordingly */
     if ((fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK)) < 0) {
         perror("open");
-        printf("Try running the application using sudo so it has access to /dev/uinput\n");
+        printf("No access to /dev/uinput. ! DO NOT USE SUDO ! See Readme.md\n");
         return 1;
     }
 


### PR DESCRIPTION
I have been experimenting with retropie and was having some real issues getting the emulators to recognize the simulated mouse.

After a bit of digging it appears that the uinput module needs to have user lever access instead of root access in order to read the events created by xwiigun-mouse. I have appended some instructions to the readme.md aswell as creating a folder called additional with a script that will apply permanent changes to uinput for those who require it.

Would the instructions be better in the wiki instead of the readme.md? My reason for putting it in the .md file is because it is referenced in the mouse.c file.